### PR TITLE
fix task not being strikethrough when dragged to completed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,8 +49,10 @@ const App: React.FC = () => {
     }
     // Destination Logic
     if (destination.droppableId === "TodosTabs") {
+      add.isDone = false;
       active.splice(destination.index, 0, add);
     } else {
+      add.isDone = true;
       complete.splice(destination.index, 0, add);
     }
     setcompletedTodos(complete);


### PR DESCRIPTION
Fixed a minor issue when a todo task is dragged to completed, it was not being strikethrough (isDone was not being set to true).